### PR TITLE
fix: chat reactions slash shortcut on firefox

### DIFF
--- a/pages/live-cursors-chat-reactions.tsx
+++ b/pages/live-cursors-chat-reactions.tsx
@@ -117,8 +117,17 @@ function LiveCursorsChatReactions() {
 
     window.addEventListener("keyup", onKeyUp);
 
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "/") {
+        e.preventDefault();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+
     return () => {
       window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("keydown", onKeyDown);
     };
   }, [updateMyPresence]);
 


### PR DESCRIPTION
https://www.notion.so/liveblocks/Fix-Firefox-message-shortcut-on-cursor-reaction-example-0d2f85a134c445c8a9834591091939da